### PR TITLE
Adds transform propery to IconPath

### DIFF
--- a/src/lib-components/IconPath.vue
+++ b/src/lib-components/IconPath.vue
@@ -1,46 +1,43 @@
 <template>
   <!-- v-bind="options" -->
-  <path
-      v-bind="options"
-      :d="path"
-      :key="Math.random().toString()"
-  />
+  <path v-bind="options" :d="path" :key="Math.random().toString()" />
 </template>
 
 <script>
 export default {
-  name: 'IconPath',
+  name: "IconPath",
   props: {
     icon: {
-      type:  Array,
-      required: true
+      type: Array,
+      required: true,
     },
     index: {
       type: Number,
-      required: true
+      required: true,
     },
     path: {
-      type: String
+      type: String,
     },
     stroke: {
-      type: String
+      type: String,
     },
     fill: {
-      type: String
-    }
+      type: String,
+    },
   },
   computed: {
-    options () {
-      const {stroke, icon, index, fill} = this;
+    options() {
+      const { stroke, icon, index, fill } = this;
 
       return {
         stroke: stroke || icon[3][index].stroke,
         fill: fill || icon[3][index].fill,
-        'stroke-linecap': icon[3][index]['stroke-linecap'],
-        'stroke-linejoin': icon[3][index]['stroke-linejoin'],
-        'stroke-width': icon[3][index]['stroke-width'],
-      }
-    }
-  }
-}
+        "stroke-linecap": icon[3][index]["stroke-linecap"],
+        "stroke-linejoin": icon[3][index]["stroke-linejoin"],
+        "stroke-width": icon[3][index]["stroke-width"],
+        transform: icon[3][index]["transform"],
+      };
+    },
+  },
+};
 </script>


### PR DESCRIPTION
Fix broken icons on vue wrapper: 
![image](https://user-images.githubusercontent.com/4266657/109701976-68d1cc00-7b72-11eb-881d-24cecf1a70bf.png)


Just this line was changed: ` transform: icon[3][index]["transform"],`

other lines are just automatic formatting
